### PR TITLE
extract support lib

### DIFF
--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -8,7 +8,7 @@ version_info = 0, 58, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 52, 'dev0'
+version_info = 0, 53, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/reader/cython/README.rst
+++ b/ansys/mapdl/reader/cython/README.rst
@@ -1,0 +1,31 @@
+======================================================
+ansys-mapdl-reader-support - Support library for pyMAPDL Reader
+======================================================
+
+This is a support library for the legacy pyMAPDL Reader library.  It
+only contains Cython libraries used by the same.
+
+
+Installation
+------------
+Installation through pip::
+
+   pip install ansys-mapdl-reader-support
+
+You can also visit `pymapdl-reader <https://github.com/pyansys/pymapdl-reader>`_
+to download the source or releases from GitHub.
+
+Developing on Windows
+---------------------
+
+This package is designed to be developed on Linux, and if you need to develop on Windows
+you will need to install your own C++ compiler. We recommend:
+
+ 1. Install Visual C++
+        a. See `here <https://wiki.python.org/moin/WindowsCompilers>`_ for a list of which Python versions correspond to which Visual C++ version
+        b. Only Python <= 3.8 appears to be supported at the moment.
+ 2. Install the development version of pymapdl-reader-support to your Python environment
+        a. Navigate to the pyMAPDL Reader project's top level (4 levels up from this file)
+        b. run ``pip install -e ansys/mapdl/reader/cython``
+
+To get the package up and running.

--- a/ansys/mapdl/reader/cython/setup.py
+++ b/ansys/mapdl/reader/cython/setup.py
@@ -1,0 +1,159 @@
+"""Installation file for ansys-mapdl-reader-support"""
+from io import open as io_open
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
+import os
+import platform
+import re
+import struct
+import subprocess
+import sys
+
+import numpy as np
+
+# Facilities to install properly on Mac using clang
+def is_clang(bin):
+    proc = subprocess.Popen([bin, '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    output = str(b'\n'.join([stdout, stderr]).decode('ascii', 'ignore'))
+    return not re.search(r'clang', output) is None
+
+
+class build_ext(_build_ext):
+    """ build class that includes numpy directory """
+
+    def build_extensions(self):
+        if os.name != 'nt':
+            binary = self.compiler.compiler[0]
+            if is_clang(binary):
+                for e in self.extensions:
+                    e.extra_compile_args.append('-stdlib=libc++')
+
+                    if platform.system() == 'Darwin':
+                        # get the minor version
+                        mac_version, _, _ = platform.mac_ver()
+                        minor = [int(n) for n in mac_version.split('.')][1]
+
+                        # libstdc++ is deprecated in recent versions of XCode
+                        if minor >= 9:
+                            e.extra_compile_args.append('-mmacosx-version-min=10.9')
+                            e.extra_compile_args.append('-stdlib=libc++')
+                            e.extra_link_args.append('-mmacosx-version-min=10.9')
+                            e.extra_link_args.append('-stdlib=libc++')
+                        else:
+                            e.extra_compile_args.append('-mmacosx-version-min=10.7')
+                            e.extra_link_args.append('-mmacosx-version-min=10.7')
+
+        _build_ext.build_extensions(self)
+
+
+def compiler_name():
+    """ Check compiler and assign compile arguments accordingly """
+    import re
+    import distutils.ccompiler
+    comp = distutils.ccompiler.get_default_compiler()
+    getnext = False
+
+    for a in sys.argv[2:]:
+        if getnext:
+            comp = a
+            getnext = False
+            continue
+        # separated by space
+        if a == '--compiler' or re.search('^-[a-z]*c$', a):
+            getnext = True
+            continue
+        # without space
+        m = re.search('^--compiler=(.+)', a)
+        if m is None:
+            m = re.search('^-[a-z]*c(.+)', a)
+            if m:
+                comp = m.group(1)
+
+    return comp
+
+
+# Assign arguments based on compiler
+compiler = compiler_name()
+if compiler == 'unix':
+    cmp_arg = ['-O3', '-w']
+else:
+    cmp_arg = ['/Ox', '-w']
+
+
+# Get version from version info
+__version__ = "0.0.dev0"
+install_requires = [
+    'numpy>=1.16.0'
+]
+
+# perform python version checking
+# this is necessary to avoid the new pip package checking as vtk does
+# not support Python 32-bit as of 17 June 2021.
+is64 = struct.calcsize("P") * 8 == 64
+if not is64:
+    raise RuntimeError('\n\n``ansys-mapdl-reader`` requires 64-bit Python.\n'
+                       'Please check the version of Python installed at\n'
+                       '%s' % sys.executable)
+
+setup(
+    name='ansys-mapdl-reader-support',
+    version=__version__,
+    description='Support library for ansys.mapdl.reader',
+    long_description=open('README.rst').read(),
+    long_description_content_type='text/x-rst',
+    license='MIT',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: Information Analysis',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX',
+        'Operating System :: MacOS',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
+    url='https://github.com/pyansys/pymapdl-reader/ansys/mapdl/reader/cython',
+
+    # Build cython modules
+    cmdclass={'build_ext': build_ext},
+    include_dirs=[np.get_include()],
+    ext_modules=[
+                 Extension('ansys.mapdl.reader._archive',
+                           ['_archive.pyx',
+                            'archive.c'],
+                           extra_compile_args=cmp_arg,
+                           language='c',),
+
+                 Extension('ansys.mapdl.reader._reader',
+                           ['_reader.pyx',
+                            'reader.c',
+                            'vtk_support.c'],
+                           extra_compile_args=cmp_arg,
+                           language='c',),
+
+                 Extension("ansys.mapdl.reader._relaxmidside",
+                           ["_relaxmidside.pyx"],
+                           extra_compile_args=cmp_arg,
+                           language='c'),
+
+                 Extension("ansys.mapdl.reader._cellqual",
+                           ["_cellqual.pyx"],
+                           extra_compile_args=cmp_arg,
+                           language='c'),
+
+                 Extension("ansys.mapdl.reader._binary_reader",
+                           ["_binary_reader.pyx",
+                            "binary_reader.cpp"],
+                           extra_compile_args=cmp_arg,
+                           language='c++'),
+                 ],
+
+    python_requires='>=3.7.*',
+    keywords='vtk MAPDL ANSYS cdb full rst',
+    install_requires=install_requires,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,85 +1,7 @@
 """Installation file for ansys-mapdl-reader"""
 from io import open as io_open
-from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext as _build_ext
 import os
-import platform
-import re
-import struct
-import subprocess
-import sys
-
-import numpy as np
-
-# Facilities to install properly on Mac using clang
-def is_clang(bin):
-    proc = subprocess.Popen([bin, '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = proc.communicate()
-    output = str(b'\n'.join([stdout, stderr]).decode('ascii', 'ignore'))
-    return not re.search(r'clang', output) is None
-
-
-class build_ext(_build_ext):
-    """ build class that includes numpy directory """
-
-    def build_extensions(self):
-        if os.name != 'nt':
-            binary = self.compiler.compiler[0]
-            if is_clang(binary):
-                for e in self.extensions:
-                    e.extra_compile_args.append('-stdlib=libc++')
-
-                    if platform.system() == 'Darwin':
-                        # get the minor version
-                        mac_version, _, _ = platform.mac_ver()
-                        minor = [int(n) for n in mac_version.split('.')][1]
-
-                        # libstdc++ is deprecated in recent versions of XCode
-                        if minor >= 9:
-                            e.extra_compile_args.append('-mmacosx-version-min=10.9')
-                            e.extra_compile_args.append('-stdlib=libc++')
-                            e.extra_link_args.append('-mmacosx-version-min=10.9')
-                            e.extra_link_args.append('-stdlib=libc++')
-                        else:
-                            e.extra_compile_args.append('-mmacosx-version-min=10.7')
-                            e.extra_link_args.append('-mmacosx-version-min=10.7')
-
-        _build_ext.build_extensions(self)
-
-
-def compiler_name():
-    """ Check compiler and assign compile arguments accordingly """
-    import re
-    import distutils.ccompiler
-    comp = distutils.ccompiler.get_default_compiler()
-    getnext = False
-
-    for a in sys.argv[2:]:
-        if getnext:
-            comp = a
-            getnext = False
-            continue
-        # separated by space
-        if a == '--compiler' or re.search('^-[a-z]*c$', a):
-            getnext = True
-            continue
-        # without space
-        m = re.search('^--compiler=(.+)', a)
-        if m is None:
-            m = re.search('^-[a-z]*c(.+)', a)
-            if m:
-                comp = m.group(1)
-
-    return comp
-
-
-# Assign arguments based on compiler
-compiler = compiler_name()
-if compiler == 'unix':
-    cmp_arg = ['-O3', '-w']
-else:
-    cmp_arg = ['/Ox', '-w']
-
+from setuptools import setup
 
 # Get version from version info
 __version__ = None
@@ -94,20 +16,9 @@ install_requires = [
     'pyvista>=0.32.0',
     'appdirs>=1.4.0',
     'matplotlib>=3.0.0',
-    'tqdm>=4.45.0'
+    'tqdm>=4.45.0',
+    'ansys-mapdl-reader-support'
 ]
-
-# perform python version checking
-# this is necessary to avoid the new pip package checking as vtk does
-# not support Python 32-bit as of 17 June 2021.
-is64 = struct.calcsize("P") * 8 == 64
-if not is64:
-    try:
-        import vtk
-    except ImportError:
-        raise RuntimeError('\n\n``ansys-mapdl-reader`` requires 64-bit Python due to vtk.\n'
-                           'Please check the version of Python installed at\n'
-                           '%s' % sys.executable)
 
 setup(
     name='ansys-mapdl-reader',
@@ -132,41 +43,6 @@ setup(
         'Programming Language :: Python :: 3.10',
     ],
     url='https://github.com/pyansys/pymapdl-reader',
-
-    # Build cython modules
-    cmdclass={'build_ext': build_ext},
-    include_dirs=[np.get_include()],
-    ext_modules=[
-                 Extension('ansys.mapdl.reader._archive',
-                           ['ansys/mapdl/reader/cython/_archive.pyx',
-                            'ansys/mapdl/reader/cython/archive.c'],
-                           extra_compile_args=cmp_arg,
-                           language='c',),
-
-                 Extension('ansys.mapdl.reader._reader',
-                           ['ansys/mapdl/reader/cython/_reader.pyx',
-                            'ansys/mapdl/reader/cython/reader.c',
-                            'ansys/mapdl/reader/cython/vtk_support.c'],
-                           extra_compile_args=cmp_arg,
-                           language='c',),
-
-                 Extension("ansys.mapdl.reader._relaxmidside",
-                           ["ansys/mapdl/reader/cython/_relaxmidside.pyx"],
-                           extra_compile_args=cmp_arg,
-                           language='c'),
-
-                 Extension("ansys.mapdl.reader._cellqual",
-                           ["ansys/mapdl/reader/cython/_cellqual.pyx"],
-                           extra_compile_args=cmp_arg,
-                           language='c'),
-
-                 Extension("ansys.mapdl.reader._binary_reader",
-                           ["ansys/mapdl/reader/cython/_binary_reader.pyx",
-                            "ansys/mapdl/reader/cython/binary_reader.cpp"],
-                           extra_compile_args=cmp_arg,
-                           language='c++'),
-                 ],
-
     python_requires='>=3.7.*',
     keywords='vtk MAPDL ANSYS cdb full rst',
     package_data={'ansys.mapdl.reader.examples': ['TetBeam.cdb',


### PR DESCRIPTION
Completely decoupling pymapdl-reader from pyvista is not possible.  Completely decoupling pymapdl from pymapdl-reader is a long term effort, but it looks like the main remaining required usage of pymapdl-reader after my open PR in pymapdl depends on the cython libraries here.

In order to then decouple pymapdl from pyvista, I propose to split pymapdl-reader into two packages
ansys.mapdl.reader
ansys.mapdl.reader.support

The latter will contain all the cython libraries used by ansys.mapdl.reader, and the former will contain what is left over.  I imagine that there is no reason to create a new repo.

ansys.mapdl.reader will of course depend on ansys.mapdl.reader.support, and ansys.mapdl.core will depend on both.  The last required usage of ansys.mapdl.reader in ansys.mapdl.core can then be changed to ansys.mapdl.reader.support