### PR TITLE
Standardizing Windows data path and removing folder creation on import

### DIFF
--- a/ansys/mapdl/reader/__init__.py
+++ b/ansys/mapdl/reader/__init__.py
@@ -21,12 +21,8 @@ from . import _archive
 
 # Setup data directory
 USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_mapdl_reader", appauthor="Ansys")
-if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
-    os.makedirs(USER_DATA_PATH)
 
 EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
-    os.makedirs(EXAMPLES_PATH)
 
 # set pyvista defaults
 _configure_pyvista()

--- a/ansys/mapdl/reader/__init__.py
+++ b/ansys/mapdl/reader/__init__.py
@@ -20,17 +20,13 @@ from ansys.mapdl.reader.misc import Report, _configure_pyvista
 from . import _archive
 
 # Setup data directory
-try:
-    USER_DATA_PATH = appdirs.user_data_dir("ansys_mapdl_reader")
-    if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
-        os.makedirs(USER_DATA_PATH)
+USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_mapdl_reader", appauthor="Ansys")
+if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
+    os.makedirs(USER_DATA_PATH)
 
-    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-    if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
-        os.makedirs(EXAMPLES_PATH)
-
-except:  # pragma: no cover
-    pass
+EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
+if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
+    os.makedirs(EXAMPLES_PATH)
 
 # set pyvista defaults
 _configure_pyvista()

--- a/ansys/mapdl/reader/examples/downloads.py
+++ b/ansys/mapdl/reader/examples/downloads.py
@@ -32,6 +32,9 @@ def _get_file_url(filename):
 
 
 def _retrieve_file(url, filename):
+    if not os.path.exists(pymapdl_reader.EXAMPLES_PATH):
+        os.makedirs(pymapdl_reader.EXAMPLES_PATH)
+
     # First check if file has already been downloaded
     local_path = os.path.join(pymapdl_reader.EXAMPLES_PATH, os.path.basename(filename))
     local_path_no_zip = local_path.replace(".zip", "")


### PR DESCRIPTION
Same user data path naming scheme as in https://github.com/ansys/pyfluent/pull/1615, https://github.com/ansys/pymapdl/pull/2064, https://github.com/ansys/pyprimemesh/pull/485, https://github.com/ansys/ansys-tools-path/pull/44, https://github.com/ansys/pysystem-coupling/pull/158, https://github.com/ansys/pymechanical/pull/257

Original issue tracker https://github.com/ansys/pyfluent/issues/1588

Changes Windows data path from `%LocalAppData%\ansys_mapdl_reader\ansys_mapdl_reader` to `%LocalAppData%\Ansys\ansys_mapdl_reader`, no change to the path on Linux

Removed what looks like an unnecessary try-except block

Also changed it so that the examples and data path folders are not created immediately on import regardless of whether they will be used. They are instead created when downloading example files through `downloads._retrieve_file()`, as that seems to be the only place where these directories were used in this module