### PR TITLE
Remove usage of _vtk

### DIFF
--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -3,7 +3,9 @@ from functools import wraps
 
 import numpy as np
 import pyvista as pv
-from pyvista._vtk import vtkAppendFilter, vtkMatrix4x4, vtkTransform
+from vtkmodules.vtkCommonMath import vtkMatrix4x4
+from vtkmodules.vtkCommonTransforms import vtkTransform
+from vtkmodules.vtkFiltersCore import vtkAppendFilter
 
 from ansys.mapdl.reader import _binary_reader
 from ansys.mapdl.reader.common import (

--- a/ansys/mapdl/reader/dis_result.py
+++ b/ansys/mapdl/reader/dis_result.py
@@ -8,7 +8,7 @@ from typing import Union
 
 import numpy as np
 import pyvista as pv
-from pyvista._vtk import vtkAppendFilter
+from vtkmodules.vtkFiltersCore import vtkAppendFilter
 
 from ansys.mapdl.reader._binary_reader import read_nodal_values_dist
 from ansys.mapdl.reader._rst_keys import element_index_table_info

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -4,22 +4,24 @@ import pathlib
 import numpy as np
 import pytest
 import pyvista as pv
+from pyvista import CellType
 from pyvista import examples as pyvista_examples
-from pyvista._vtk import (
-    VTK_HEXAHEDRON,
-    VTK_PYRAMID,
-    VTK_QUADRATIC_HEXAHEDRON,
-    VTK_QUADRATIC_PYRAMID,
-    VTK_QUADRATIC_TETRA,
-    VTK_QUADRATIC_WEDGE,
-    VTK_TETRA,
-    VTK_WEDGE,
-)
 
 from ansys.mapdl import reader as pymapdl_reader
 from ansys.mapdl.reader import _archive, archive, examples
 
-LINEAR_CELL_TYPES = [VTK_TETRA, VTK_PYRAMID, VTK_WEDGE, VTK_HEXAHEDRON]
+LINEAR_CELL_TYPES = [
+    CellType.TETRA,
+    CellType.PYRAMID,
+    CellType.WEDGE,
+    CellType.HEXAHEDRON,
+]
+QUADRATIC_CELL_TYPES = [
+    CellType.QUADRATIC_TETRA,
+    CellType.QUADRATIC_PYRAMID,
+    CellType.QUADRATIC_WEDGE,
+    CellType.QUADRATIC_HEXAHEDRON,
+]
 
 TEST_PATH = os.path.dirname(os.path.abspath(__file__))
 TESTFILES_PATH = os.path.join(TEST_PATH, "test_data")
@@ -156,7 +158,7 @@ def test_missing_midside():
     archive = pymapdl_reader.Archive(archive_file, allowable_types=allowable_types)
 
     assert (archive.quality > 0.0).all()
-    assert not np.any(archive.grid.celltypes == VTK_TETRA)
+    assert not np.any(archive.grid.celltypes == CellType.TETRA)
 
 
 def test_missing_midside_write(tmpdir):
@@ -321,15 +323,7 @@ def test_read_complex_archive_linear(all_solid_cells_archive_linear):
     assert np.all(all_solid_cells_archive_linear.quality > 0.0)
 
 
-@pytest.mark.parametrize(
-    "celltype",
-    [
-        VTK_QUADRATIC_TETRA,
-        VTK_QUADRATIC_PYRAMID,
-        VTK_QUADRATIC_WEDGE,
-        VTK_QUADRATIC_HEXAHEDRON,
-    ],
-)
+@pytest.mark.parametrize("celltype", QUADRATIC_CELL_TYPES)
 def test_write_quad_complex_archive(tmpdir, celltype, all_solid_cells_archive):
     grid = all_solid_cells_archive.grid
     mask = grid.celltypes == celltype


### PR DESCRIPTION
Upcoming PyVista 0.40 release will completely remove the ``_vtk`` module. This PR removes the usage of it and also incorporates the new ``CellTypes`` [enum](https://docs.python.org/3/library/enum.html).
