### PR TITLE
feat: drop Python 3.8 support

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -131,8 +131,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
-        with:
-            python-version: 3.8 - 3.11
 
       - name: List generated wheels
         run: |

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Operating System :: MacOS",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -91,7 +90,7 @@ setup(
             language="c++",
         ),
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.7,<4",
     keywords="vtk MAPDL ANSYS cdb full rst",
     package_data={
         "ansys.mapdl.reader.examples": [


### PR DESCRIPTION
According to https://adrs.ansys.com/docs/adrs/0021-python-version-support/ PyAnsys libraries are now following [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html) whenever possible.

This implies that support for Python 3.8 is no longer given (active testing). We will continue to let the ``setup.py`` to allow its build but no wheels will be provided through PyPI.