### PR TITLE
Add helpful error when failing to read compressed result files

### DIFF
--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -232,17 +232,15 @@ class Result(AnsysBinary):
         # consider moving this to the main class
         standard_header = read_standard_header(self.filename)
 
-        # Read .RST FILE HEADER
-        try:
-            record = self.read_record(103)
-            if record.size > 80:
-                raise RuntimeError("Invalid record size. Should be 80 entries")
-            header = parse_header(record, result_header_keys)
-        except:
+        # Read .rst file header. Header must contain 80 items
+        record = self.read_record(103)
+        if record.size > 80:
             raise RuntimeError(
-                "Unable to read result header. Try disabling compression with:\n\n"
+                "Unable to read result header. Try disabling MAPDL compression with:\n\n"
                 "    /FCOMP,RST,0"
             )
+        header = parse_header(record, result_header_keys)
+
         resultheader = merge_two_dicts(header, standard_header)
 
         # Read nodal equivalence table

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -233,7 +233,16 @@ class Result(AnsysBinary):
         standard_header = read_standard_header(self.filename)
 
         # Read .RST FILE HEADER
-        header = parse_header(self.read_record(103), result_header_keys)
+        try:
+            record = self.read_record(103)
+            if record.size > 80:
+                raise RuntimeError("Invalid record size. Should be 80 entries")
+            header = parse_header(record, result_header_keys)
+        except:
+            raise RuntimeError(
+                "Unable to read result header. Try disabling compression with:\n\n"
+                "    /FCOMP,RST,0"
+            )
         resultheader = merge_two_dicts(header, standard_header)
 
         # Read nodal equivalence table


### PR DESCRIPTION
Resolve #409 by adding a helpful error when failing to read compressed result files, suggesting the user disable compression with `/FCOMP,RST,0`.