### PR TITLE
Support numpy 2.0

### DIFF
--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -364,7 +364,7 @@ cdef np.ndarray wrap_array(void* c_ptr, int size, int type_flag, int prec_flag):
     array_wrapper.set_data(size, c_ptr, my_dtype)
 
     cdef np.ndarray ndarray
-    ndarray = np.array(array_wrapper, copy=False)
+    ndarray = np.array(array_wrapper)
 
     # Assign our object to the 'base' of the ndarray object
     np.PyArray_SetBaseObject(ndarray, array_wrapper)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "cython==3.0.5",
-    "oldest-supported-numpy",
+    "cython>=3.0.0",
+    "numpy>=2,<3",
     "setuptools>=45.0",
     "wheel>=0.37.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "appdirs>=1.4.0",
         "matplotlib>=3.0.0",
-        "numpy>=1.16.0,<2",
+        "numpy>=2,<3",
         "pyvista>=0.32.0,<0.44",
         "tqdm>=4.45.0",
         "vtk>=9.0.0",


### PR DESCRIPTION
Add support for numpy 2.0 by building with numpy 2.0 and requiring at least numpy 2.0.

Users who've not made the switch can still work with the previous release which will be automatically resolved by pip (as it is, for example, with `matplotlib`).
