### PR TITLE
fix: allow for numpy 1.X backwards compatibility

### DIFF
--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -368,7 +368,7 @@ cdef np.ndarray wrap_array(void* c_ptr, int size, int type_flag, int prec_flag):
     if np.__version__.startswith("1."): # Backwards compatibility with numpy 1.X
         ndarray = np.array(array_wrapper, copy=False)
     else:
-        ndarray = np.array(array_wrapper)
+        ndarray = np.array(array_wrapper, copy=None)
 
     # Assign our object to the 'base' of the ndarray object
     np.PyArray_SetBaseObject(ndarray, array_wrapper)

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -364,7 +364,11 @@ cdef np.ndarray wrap_array(void* c_ptr, int size, int type_flag, int prec_flag):
     array_wrapper.set_data(size, c_ptr, my_dtype)
 
     cdef np.ndarray ndarray
-    ndarray = np.array(array_wrapper)
+    # TODO: Remove backwards compatibility in the future
+    if np.__version__.startswith("1."): # Backwards compatibility with numpy 1.X
+        ndarray = np.array(array_wrapper, copy=False)
+    else:
+        ndarray = np.array(array_wrapper)
 
     # Assign our object to the 'base' of the ndarray object
     np.PyArray_SetBaseObject(ndarray, array_wrapper)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "cython>=3.0.0",
-    "numpy>=2,<3",
+    "numpy>=1,<3",
     "setuptools>=45.0",
     "wheel>=0.37.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "cython>=3.0.0",
-    "numpy>=1,<3",
+    "numpy>=1.16.0,<3",
     "setuptools>=45.0",
     "wheel>=0.37.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "appdirs>=1.4.0",
         "matplotlib>=3.0.0",
-        "numpy>=1,<3",
+        "numpy>=1.16.0,<3",
         "pyvista>=0.32.0,<0.44",
         "tqdm>=4.45.0",
         "vtk>=9.0.0",

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "appdirs>=1.4.0",
         "matplotlib>=3.0.0",
-        "numpy>=2,<3",
+        "numpy>=1,<3",
         "pyvista>=0.32.0,<0.44",
         "tqdm>=4.45.0",
         "vtk>=9.0.0",


### PR DESCRIPTION
As title says. Allowing compatibility with both NumPy major versions (for now)