### PR TITLE
fix: reverting limit support for PyVista

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         "appdirs>=1.4.0",
         "matplotlib>=3.0.0",
         "numpy>=1.16.0,<3",
-        "pyvista>=0.32.0,<0.44",
+        "pyvista>=0.32.0",
         "tqdm>=4.45.0",
         "vtk>=9.0.0",
     ],


### PR DESCRIPTION
Reverting #461 after #476 was merged.