### PR TITLE
fix: numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "cython>=3.0.0",
-    "numpy>=1.16.0,<3",
+    "numpy>=1.16.0,<2.1.2", #Something broke in 2.1.2
     "setuptools>=45.0",
     "wheel>=0.37.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "cython>=3.0.0",
-    "numpy>=1.16.0,<2.1.2", #Something broke in 2.1.2
+    "numpy>=1.16.0,<2.1.2", # Something broke in 2.1.2
     "setuptools>=45.0",
     "wheel>=0.37.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "cython>=3.0.0",
-    "numpy>=1.16.0,<2.1.2", # Something broke in 2.1.2
+    "numpy>=1.16.0,<2.1", # Something broke in 2.1.x
     "setuptools>=45.0",
     "wheel>=0.37.0",
 ]


### PR DESCRIPTION
Something broke in the 2.1.x release of NumPy and we don't have the manpower to fix it. Solution is to limit the version or comment out the test - up to you @germa89. See for the failing tests: https://github.com/ansys/pymapdl-reader/actions/runs/11258505485/job/31305260737?pr=502#step:11:564

Honestly, if we still want to deliver it, capping the upper limit is probably not a good solution and we prefer to comment out the test. However, I do not have the knowledge of the internals of this library and it might be causing other side effects