### PR TITLE
fix add-text behavior

### DIFF
--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -3119,9 +3119,11 @@ class Result(AnsysBinary):
             else:
                 plotter.open_movie(movie_filename)
 
-        if add_text and rnum is not None and not animate:
+        if add_text and rnum is not None:
             result_text = self.text_result_table(rnum)
-            plotter.add_text(result_text, font_size=font_size, color=text_color)
+            if not animate:
+                # avoid adding twice
+                plotter.add_text(result_text, font_size=font_size, color=text_color)
 
         # camera position added in 0.32.0
         show_kwargs = {}

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -3119,7 +3119,7 @@ class Result(AnsysBinary):
             else:
                 plotter.open_movie(movie_filename)
 
-        if add_text and rnum is not None:
+        if add_text and rnum is not None and not animate:
             result_text = self.text_result_table(rnum)
             plotter.add_text(result_text, font_size=font_size, color=text_color)
 


### PR DESCRIPTION
Resolve #558 by fixing the add_text behavior. 

##### Example behavior from this PR

Generate a movie of a mode shape while plotting off-screen.

```py
>>> from ansys.mapdl.reader import read_binary
>>> rst = read_binary("academic_rotor.rst")
>>> rst.animate_nodal_displacement(
...     (3, 2),
...     displacement_factor=0.02,
...     movie_filename="movie.mp4",
...     off_screen=True
... )

```
https://github.com/user-attachments/assets/559be0fd-468f-444b-8367-bc80c02e6527


