### PR TITLE
address np.in1d deprecation

### DIFF
--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -256,7 +256,7 @@ class Archive(Mesh):
         """Plot the mesh"""
         if self._grid is None:  # pragma: no cover
             raise AttributeError(
-                "Archive must be parsed as a vtk grid.\n" "Set `parse_vtk=True`"
+                "Archive must be parsed as a vtk grid.\nSet `parse_vtk=True`"
             )
         kwargs.setdefault("color", "w")
         kwargs.setdefault("show_edges", True)
@@ -404,7 +404,7 @@ def save_as_archive(
         # VTK_QUADRATIC_QUAD
 
     # extract allowable cell types
-    mask = np.in1d(grid.celltypes, allowable)
+    mask = np.isin(grid.celltypes, allowable)
     if not mask.any():
         ucelltypes = np.unique(grid.celltypes)
         allowable.sort()
@@ -440,8 +440,7 @@ def save_as_archive(
             nadd = np.sum(nodenum == -1)
             end_num = start_num + nadd
             log.info(
-                "FEM missing some node numbers.  Adding node numbering "
-                "from %d to %d",
+                "FEM missing some node numbers.  Adding node numbering from %d to %d",
                 start_num,
                 end_num,
             )
@@ -464,8 +463,7 @@ def save_as_archive(
     if np.any(enum == -1):
         if not allow_missing:
             raise Exception(
-                '-1 encountered in "ansys_elem_num".\n'
-                'Exiting due "allow_missing=False"'
+                '-1 encountered in "ansys_elem_num".\nExiting due "allow_missing=False"'
             )
 
         start_num = enum.max() + 1

--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -539,7 +539,7 @@ class CyclicResult(Result):
             if nnum.size < self._mas_ind.size:
                 # node numbers of the master sector
                 nnum_mas = self._neqv[self._mas_ind]
-                mask = np.in1d(nnum, nnum_mas)
+                mask = np.isin(nnum, nnum_mas)
                 nnum = nnum[mask]
                 result = full_result[mask]
             else:

--- a/ansys/mapdl/reader/dis_result.py
+++ b/ansys/mapdl/reader/dis_result.py
@@ -79,10 +79,10 @@ class DistributedResult(Result):
         ptr = self._main_result._resultheader["ptrGNOD"]
         gl_nnum = self._main_result.read_record(ptr)
 
-        mask = np.in1d(gl_nnum, self._main_result.mesh.nnum, assume_unique=True)
+        mask = np.isin(gl_nnum, self._main_result.mesh.nnum, assume_unique=True)
         for index in range(1, len(filenames)):
             result = Result(filenames[index])
-            new_mask = np.in1d(gl_nnum, result.mesh.nnum, assume_unique=True)
+            new_mask = np.isin(gl_nnum, result.mesh.nnum, assume_unique=True)
             if not new_mask.any():  # pragma: no cover
                 raise RuntimeError(
                     "File %s not part of the distributed result" % filenames[index]

--- a/ansys/mapdl/reader/full.py
+++ b/ansys/mapdl/reader/full.py
@@ -331,7 +331,7 @@ class FullFile(AnsysBinary):
                 from scipy.sparse import coo_matrix, csc_matrix
             except ImportError:
                 raise ImportError(
-                    "Unable to load scipy, use ``load_km`` with " "``as_sparse=False``"
+                    "Unable to load scipy, use ``load_km`` with ``as_sparse=False``"
                 )
 
         # number of terms in stiffness matrix
@@ -383,13 +383,13 @@ class FullFile(AnsysBinary):
         if np.any(const < 0):
             if kdata is not None:
                 remove = np.nonzero(const < 0)[0]
-                mask = ~np.logical_or(np.in1d(krow, remove), np.in1d(kcol, remove))
+                mask = ~np.logical_or(np.isin(krow, remove), np.isin(kcol, remove))
                 krow = krow[mask]
                 kcol = kcol[mask]
                 kdata = kdata[mask]
 
             if mdata is not None:
-                mask = ~np.logical_or(np.in1d(mrow, remove), np.in1d(mcol, remove))
+                mask = ~np.logical_or(np.isin(mrow, remove), np.isin(mcol, remove))
                 mrow = mrow[mask]
                 mcol = mcol[mask]
                 mdata = mdata[mask]

--- a/ansys/mapdl/reader/mesh.py
+++ b/ansys/mapdl/reader/mesh.py
@@ -8,7 +8,7 @@ from ansys.mapdl.reader.elements import ETYPE_MAP
 from ansys.mapdl.reader.misc import unique_rows
 
 INVALID_ALLOWABLE_TYPES = TypeError(
-    "`allowable_types` must be an array " "of ANSYS element types from 1 and 300"
+    "`allowable_types` must be an array of ANSYS element types from 1 and 300"
 )
 
 # map MESH200 elements to a pymapdl_reader/VTK element type (see elements.py)
@@ -239,12 +239,12 @@ class Mesh:
         # add components
         # Add element components to unstructured grid
         for key, item in self.element_components.items():
-            mask = np.in1d(self.enum, item, assume_unique=True)
+            mask = np.isin(self.enum, item, assume_unique=True)
             grid.cell_data[key] = mask
 
         # Add node components to unstructured grid
         for key, item in self.node_components.items():
-            mask = np.in1d(nnum, item, assume_unique=True)
+            mask = np.isin(nnum, item, assume_unique=True)
             grid.point_data[key] = mask
 
         # store node angles

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -829,7 +829,7 @@ class Result(AnsysBinary):
         if nnum.size != npoints:
             new_scalars = np.zeros(npoints)
             nnum_grid = self.grid.point_data["ansys_node_num"]
-            new_scalars[np.in1d(nnum_grid, nnum, assume_unique=True)] = scalars
+            new_scalars[np.isin(nnum_grid, nnum, assume_unique=True)] = scalars
             scalars = new_scalars
 
         ind = None
@@ -1593,7 +1593,7 @@ class Result(AnsysBinary):
                 mask = self.grid.point_data[nodes].view(bool)
             elif isinstance(nodes, Sequence):
                 if isinstance(nodes[0], int):
-                    mask = np.in1d(self.mesh.nnum, nodes)
+                    mask = np.isin(self.mesh.nnum, nodes)
                 elif isinstance(nodes[0], str):
                     mask = np.zeros(self.grid.n_points, bool)
                     for node_component in nodes:
@@ -1612,14 +1612,14 @@ class Result(AnsysBinary):
                 )
 
             # mask is for global nodes, need for potentially subselectd nodes
-            submask = np.in1d(nnum, self.grid.point_data["ansys_node_num"][mask])
+            submask = np.isin(nnum, self.grid.point_data["ansys_node_num"][mask])
             nnum, result = nnum[submask], result[submask]
 
         # always return the full array
         if nnum.size < self._neqv.size:
             # repopulate full array
             nnum_full = self._neqv[self._sidx]
-            mask = np.in1d(nnum_full, nnum, assume_unique=True)
+            mask = np.isin(nnum_full, nnum, assume_unique=True)
             result_full = np.empty(
                 (nnum_full.size, result.shape[1]), dtype=result.dtype
             )
@@ -1833,7 +1833,7 @@ class Result(AnsysBinary):
             self.grid = None
 
         # identify nodes that are actually in the solution
-        self._insolution = np.in1d(
+        self._insolution = np.isin(
             self._mesh.nnum, self._resultheader["neqv"], assume_unique=True
         )
 
@@ -3794,7 +3794,7 @@ class Result(AnsysBinary):
 
         if nnum_of_interest is not None:
             nnum_sel = np.unique(nnum_of_interest)
-            mask = np.in1d(self.mesh.nnum, nnum_sel)
+            mask = np.isin(self.mesh.nnum, nnum_sel)
 
             # extract any elements containing these values
             # note that we need this for accurate averaging of results
@@ -3803,10 +3803,10 @@ class Result(AnsysBinary):
             )
 
             # mask relative to global eeqv array
-            ele_mask = np.in1d(self._eeqv, grid["ansys_elem_num"], assume_unique=True)
+            ele_mask = np.isin(self._eeqv, grid["ansys_elem_num"], assume_unique=True)
 
             # verify that all nodes of interest actually occur within
-            node_mask = np.in1d(nnum_sel, grid["ansys_node_num"], assume_unique=True)
+            node_mask = np.isin(nnum_sel, grid["ansys_node_num"], assume_unique=True)
             if not node_mask.all():
                 warnings.warn(
                     "Not all nodes IDs in the ``nnum_of_interest`` "
@@ -3865,7 +3865,7 @@ class Result(AnsysBinary):
 
         if nnum_of_interest is not None:
             if grid.n_points != nnum_sel.size:
-                mask = np.in1d(grid["ansys_node_num"], nnum_sel)
+                mask = np.isin(grid["ansys_node_num"], nnum_sel)
                 nnum = grid["ansys_node_num"][mask]
                 ncount = ncount[mask]
                 data = data[mask]
@@ -4312,7 +4312,7 @@ class Result(AnsysBinary):
 
         # angles relative to the XZ plane
         if nnum.size != self._mesh.nodes.shape[0]:
-            mask = np.in1d(nnum, self._mesh.nnum)
+            mask = np.isin(nnum, self._mesh.nnum)
             angle = np.arctan2(self._mesh.nodes[mask, 1], self._mesh.nodes[mask, 0])
         else:
             angle = np.arctan2(self._mesh.nodes[:, 1], self._mesh.nodes[:, 0])

--- a/tests/elements/plane_182_183/test_plane182_183.py
+++ b/tests/elements/plane_182_183/test_plane182_183.py
@@ -60,5 +60,5 @@ def test_stress(result):
     ansys_nnum = np.load(os.path.join(testfiles_path, "prnsol_s_nnum.npy"))
     ansys_stress = np.load(os.path.join(testfiles_path, "prnsol_s.npy"))
     nnum, stress = result.nodal_stress(0)
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     assert np.allclose(stress[mask], ansys_stress, atol=1e-6)

--- a/tests/test_binary_reader.py
+++ b/tests/test_binary_reader.py
@@ -250,7 +250,7 @@ def test_prnsol_s(mapdl, cyclic_modal, rset):
     nnum, stress = mapdl.result.nodal_stress(rset)
 
     # v150 includes nodes in the geometry that aren't in the result
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     nnum = nnum[mask]
     stress = stress[mask]
 
@@ -272,7 +272,7 @@ def test_prnsol_prin(mapdl, cyclic_modal, rset):
     nnum, stress = mapdl.result.principal_nodal_stress(rset)
 
     # v150 includes nodes in the geometry that aren't in the result
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     nnum = nnum[mask]
     stress = stress[mask]
 

--- a/tests/test_cyclic.py
+++ b/tests/test_cyclic.py
@@ -114,7 +114,7 @@ def test_nodal_cyclic_modal(academic_rotor, load_step, sub_step, rtype):
         raise ValueError("rtype %s not configured in test" % rtype)
 
     # ANSYS doesn't include results for all nodes (i.e. sector nodes)
-    mask = np.in1d(nnum, nnum_ans)
+    mask = np.isin(nnum, nnum_ans)
     stress = stress[:, mask, :6]  # pymapdl_reader strain includes eqv
     nnum = nnum[mask]
     assert np.allclose(nnum, nnum_ans)
@@ -275,7 +275,7 @@ def test_full_x_nodal_solution(result_x):
 
     assert np.allclose(np.sort(nnum), nnum), "nnum must be sorted"
 
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     n = mask.sum()
     tmp = ansys_disp.reshape(disp.shape[0], n, 3)
     assert np.allclose(nnum[mask], ansys_nnum[:n])
@@ -304,7 +304,7 @@ def test_full_z_nodal_solution(cyclic_v182_z):
         rnum, phase, full_rotor=True, as_complex=False
     )
 
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     n = mask.sum()
     tmp = ansys_disp.reshape(disp.shape[0], n, 3)
     assert np.allclose(disp[:, mask], tmp)
@@ -325,7 +325,7 @@ def test_full_z_nodal_solution_phase(cyclic_v182_z):
         rnum, phase, full_rotor=True, as_complex=True
     )
 
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     n = mask.sum()
     tmp = ansys_disp.reshape(disp.shape[0], n, 3)
     assert np.allclose(disp[:, mask], tmp)
@@ -349,7 +349,7 @@ def test_full_x_nodal_stress(result_x):
     phase = 0
     nnum, stress = result_x.nodal_stress(rnum, phase, full_rotor=True)
 
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     n = mask.sum()
     tmp = ansys_stress.reshape(stress.shape[0], n, 6)
 
@@ -395,7 +395,7 @@ def test_full_x_principal_nodal_stress(result_x):
     phase = 0
     nnum, stress = result_x.principal_nodal_stress(rnum, phase, full_rotor=True)
 
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     n = mask.sum()
     tmp = ansys_stress.reshape(stress.shape[0], n, 5)
 
@@ -425,12 +425,12 @@ def test_cyclic_z_harmonic_displacement():
 
     unod, count = np.unique(ansys_nnum, return_counts=True)
     unod = np.setdiff1d(unod[count == result_z.n_sector], 32)
-    mask = np.in1d(ansys_nnum, unod)
+    mask = np.isin(ansys_nnum, unod)
     ansys_nnum = ansys_nnum[mask]
     ansys_disp = ansys_disp[mask]
 
     nnum, disp = result_z.nodal_solution((4, 2), full_rotor=True)
-    mask = np.in1d(nnum, ansys_nnum)
+    mask = np.isin(nnum, ansys_nnum)
     tmp = ansys_disp.reshape(disp.shape[0], mask.sum(), 3)
     assert np.allclose(disp[:, mask], tmp, atol=1e-5)
 
@@ -462,7 +462,7 @@ def test_nodal_elastic_strain_cyclic(result_x):
     nnum, stress = result_x.nodal_elastic_strain(0, full_rotor=True)
 
     # include only common values
-    mask = np.in1d(nnum, nnum_ans[0])
+    mask = np.isin(nnum, nnum_ans[0])
     stress = stress[:, mask, :6]  # stress includes eqv
     nnum = nnum[mask]
     assert np.allclose(nnum, nnum_ans)
@@ -505,7 +505,7 @@ def test_nodal_thermal_strain_cyclic(result_x):
     nnum, strain = result_x.nodal_thermal_strain(0, full_rotor=True)
 
     # include only common values
-    mask = np.in1d(nnum, nnum_ans)
+    mask = np.isin(nnum, nnum_ans)
     strain = strain[:, mask, :6]  # strain includes eqv
     nnum = nnum[mask]
     assert np.allclose(nnum, nnum_ans)

--- a/tests/test_dist_rst.py
+++ b/tests/test_dist_rst.py
@@ -154,7 +154,7 @@ def test_blade_result(beam_blade):
     ans_rst = np.load(filename)
 
     nnum, disp = beam_blade.nodal_displacement(0)
-    mask = np.in1d(ans_rst["nnum"], nnum)
+    mask = np.isin(ans_rst["nnum"], nnum)
     assert np.allclose(disp[:, 0], ans_rst["x_disp"][mask])
 
 

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -454,7 +454,7 @@ def test_reaction_forces(volume_rst):
 
     rforces, nnum, dof = volume_rst.nodal_reaction_forces(0)
     assert (np.diff(nnum) >= 0).all()
-    assert (np.in1d(dof, [1, 2, 3])).all()
+    assert (np.isin(dof, [1, 2, 3])).all()
     assert rforces.dtype == np.float64
 
     fz = rforces[dof == 3]
@@ -472,7 +472,7 @@ def test_nnum_of_interest(nnum_of_interest):
     nnum_sel, data_sel = rst._nodal_result(0, "ENS", nnum_of_interest=nnum_of_interest)
     nnum, data = rst._nodal_result(0, "ENS")
 
-    mask = np.in1d(nnum, nnum_of_interest)
+    mask = np.isin(nnum, nnum_of_interest)
     assert np.allclose(nnum[mask], nnum_sel)
     assert np.allclose(data[mask], data_sel, equal_nan=True)
 


### PR DESCRIPTION
Address `np.in1d` deprecation.

See: https://numpy.org/doc/stable/reference/generated/numpy.in1d.html
