### PR TITLE
chore: license classifier deprecated (PEP 621)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   PYMAPDL_START_INSTANCE: FALSE
   DOCKER_PACKAGE: ghcr.io/pyansys/pymapdl/mapdl
   DOCUMENTATION_CNAME: reader.docs.pyansys.com
-  MAIN_PYTHON_VERSION: '3.13'
+  MAIN_PYTHON_VERSION: '3.13.5'
 
 on:
   pull_request:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13.5']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   PYMAPDL_START_INSTANCE: FALSE
   DOCKER_PACKAGE: ghcr.io/pyansys/pymapdl/mapdl
   DOCUMENTATION_CNAME: reader.docs.pyansys.com
-  MAIN_PYTHON_VERSION: '3.13.5'
+  MAIN_PYTHON_VERSION: '3.13'
 
 on:
   pull_request:
@@ -60,8 +60,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13.5']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-latest]
+      # Once windows runners update their cache this has to be removed
+      # Change the 3.13 version on windows to 3.13.5
+        exclude:
+          - os: windows-latest
+            python-version: '3.13'
+        include:
+          - os: windows-latest
+            python-version: '3.13.5'
 
     steps:
       - uses: actions/checkout@v4

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -453,7 +453,7 @@ class Result(AnsysBinary):
                         # of data.
                         fs = (self._geometry_header["ptrMAT"] + ptr + 202) * 4
                         self._cfile._seekg(fs)
-                        material[key] = np.fromstring(self._cfile._read(8))[0]
+                        material[key] = np.frombuffer(self._cfile._read(8))[0]
                     else:
                         material[key] = read_mat_data(ptr)
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     maintainer="PyAnsys developers",
     maintainer_email="pyansys.maintainers@ansys.com",
     license="MIT",
-    license_files=("LICENSE",)
+    license_files=("LICENSE",),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,11 @@ setup(
     maintainer="PyAnsys developers",
     maintainer_email="pyansys.maintainers@ansys.com",
     license="MIT",
+    license_files=("LICENSE",)
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Information Analysis",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Operating System :: MacOS",


### PR DESCRIPTION
Also had to deal with...

- a deprecated Numpy API call
- a problematic Python 3.13.4 release with Windows and C-extensions https://github.com/python/cpython/issues/135151